### PR TITLE
Hide prev & next buttons in <control-bar>

### DIFF
--- a/components/control-bar.js
+++ b/components/control-bar.js
@@ -91,6 +91,10 @@ class GlueControlBar extends HTMLElement {
       button:active {
         opacity: 0.6;
       }
+
+      button.prev, button.next {
+        visibility: hidden;
+      }
     `;
   }
 }


### PR DESCRIPTION
Temporarily disabled prev & next buttons
<img width="1156" alt="image" src="https://user-images.githubusercontent.com/2025065/162483484-2ccf4249-f550-4658-a342-5311dc942642.png">
